### PR TITLE
improve: make lint:yaml script functional

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "bun run lint:js && bun run lint:filters && bun run lint:md",
     "lint:js": "eslint .",
     "lint:filters": "bunx aglint",
-    "lint:yaml": "echo 'YAML linting available in CI via yamllint action'",
+    "lint:yaml": "command -v yamllint >/dev/null && yamllint . || echo 'yamllint not installed. Install with: pip install yamllint'",
     "lint:md": "bunx markdownlint-cli2 '**/*.md' '#node_modules'",
     "lint:shell": "shellcheck Scripts/*.sh || true",
     "lint:eslint": "eslint .",


### PR DESCRIPTION
The lint:yaml script now attempts to run yamllint if it's available on the system, and provides helpful installation instructions if it's not installed. This makes the script actually useful for local development instead of just displaying a message about CI.

This change improves developer experience by allowing developers to run YAML linting locally before pushing to CI.