### PR TITLE
fix: make lint:yaml script fail when yamllint is not installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "bun run lint:js && bun run lint:filters && bun run lint:md",
     "lint:js": "eslint .",
     "lint:filters": "bunx aglint",
-    "lint:yaml": "command -v yamllint >/dev/null && yamllint . || echo 'yamllint not installed. Install with: pip install yamllint'",
+    "lint:yaml": "command -v yamllint >/dev/null && yamllint . || { echo 'yamllint not installed. Install with: pip install yamllint' >&2; exit 1; }",
     "lint:md": "bunx markdownlint-cli2 '**/*.md' '#node_modules'",
     "lint:shell": "shellcheck Scripts/*.sh || true",
     "lint:eslint": "eslint .",


### PR DESCRIPTION
Previously, the lint:yaml script would always exit with code 0 even when yamllint was not installed, because the fallback echo command always succeeded. This meant that linting could silently skip YAML validation.

Now the script properly exits with code 1 and writes to stderr when yamllint is missing, ensuring CI/CD pipelines catch this issue.