### PR TITLE
Potential fix for code scanning alert no. 147: Incomplete URL scheme check

### DIFF
--- a/userscripts/src/Mine/tweak-optimized.user.js
+++ b/userscripts/src/Mine/tweak-optimized.user.js
@@ -351,6 +351,7 @@ function restoreScripts(){
     !(src.startsWith('https://') || src.startsWith('/')) ||
     src.startsWith('javascript:') ||
     src.startsWith('data:') ||
+    src.startsWith('vbscript:') ||
     src.startsWith('//')) return;
   try {
     // Use URL constructor for absolute URLs; root-relative paths will throw unless base is provided


### PR DESCRIPTION
Potential fix for [https://github.com/Ven0m0/Ven0m0-Adblock/security/code-scanning/147](https://github.com/Ven0m0/Ven0m0-Adblock/security/code-scanning/147)

The best way to fix this problem is to explicitly check for the `vbscript:` scheme, in addition to the current checks for `javascript:` and `data:`. The new check must be case-insensitive and ignore leading whitespace, matching the approach for the other schemes.

Specifically, in file `userscripts/src/Mine/tweak-optimized.user.js`, in the function `restoreScripts`, update the conditional at lines 350–354 to also exclude URLs starting with the `vbscript:` scheme. Since other URLs are checked using `startsWith`, simply add `src.startsWith('vbscript:')` to the list. The checks should be performed on the actual value retrieved from the DOM, so, to be thorough, the comparison should be made case-insensitive and trimmed, but since the rest of the code currently doesn't perform those, simply extending the same structure is most compatible.

No dependencies or additional definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
