### PR TITLE
fix: remove deprecated workarounds for AdGuard MV2 extension bug

### DIFF
--- a/lists/sources/URLShortener.txt
+++ b/lists/sources/URLShortener.txt
@@ -8400,19 +8400,9 @@ adguard.info,adguard.com,adguard.app##.hello_from_adguard_tracking_params
 ! https://github.com/uBlockOrigin/uAssets/issues/27751
 @@||tix.axs.com^$removeparam=irclickid
 ! https://github.com/AdguardTeam/AdguardFilters/issues/199306#issuecomment-2678167845
-! BUG: https://github.com/AdguardTeam/AdguardBrowserExtension/issues/3076
-! TODO: remove when this issue is fixed in MV2 extension
-! https://github.com/AdguardTeam/AdguardFilters/issues/200080
-!+ PLATFORM(ext_ublock)
-@@||m.maoyan.com/api/mtrade/mmcs/cinema/v2/select/movie/cinemas.json$removeparam,xhr
 ! https://github.com/AdguardTeam/AdguardFilters/issues/198365
 ! https://github.com/AdguardTeam/AdguardFilters/issues/199110
-! TODO: remove when this issue is fixed - https://github.com/AdguardTeam/AdguardBrowserExtension/issues/3076
 ! https://github.com/AdguardTeam/AdguardFilters/issues/197733
-! TODO: remove when this issue is fixed - https://github.com/AdguardTeam/AdguardBrowserExtension/issues/3076
-! redirecting link on mobile from mydealz.de to Metro
-@@||rd.bizrate.com^$removeparam=utm_campaign
-@@||rd.bizrate.com^$removeparam=utm_medium
 ! reddit.com - e-mails about replies not resolving to the post
 @@||reddit.app.link^$removeparam=utm_content,domain=reddit.app.link
 ! https://github.com/AdguardTeam/AdguardFilters/issues/196067


### PR DESCRIPTION
Removed workaround rules and TODO comments for issue #3076 which has been resolved. The bug affecting $removeparam modifier has been fixed, so these exception rules are no longer needed:
- Removed maoyan.com workaround with uBlock platform directive
- Removed rd.bizrate.com exception rules
- Removed all associated TODO comments and bug documentation

Issue: https://github.com/AdguardTeam/AdguardBrowserExtension/issues/3076
Status: Closed and marked as Resolution: Fixed