### PR TITLE
Potential fix for code scanning alert no. 152: DOM text reinterpreted as HTML

### DIFF
--- a/userscripts/todo/OTHER/Reddit_Enhancer_Performance_Mode_Tools_.user.js
+++ b/userscripts/todo/OTHER/Reddit_Enhancer_Performance_Mode_Tools_.user.js
@@ -121,26 +121,70 @@
       menu.style.bottom = "auto";
     }
 
-    menu.innerHTML = `
-            <button id="re-toggle" title="Reddit Enhancer Settings">⚙️</button>
-            <div id="re-panel">
-                <label><input type="checkbox" id="re-darkMode"> Dark Mode</label><br>
-                <label><input type="checkbox" id="re-hidePromoted"> Hide Promoted Posts</label><br>
-                <label><input type="checkbox" id="re-hideSuggested"> Hide Suggested Posts</label><br>
-                <label><input type="checkbox" id="re-wideMode"> Wide Layout</label><br>
-                <label><input type="checkbox" id="re-autoExpandComments"> Auto Expand Comments</label><br>
-                <label><input type="checkbox" id="re-autoRefresh"> Auto Refresh Feed</label><br>
-                <label><input type="checkbox" id="re-performanceMode"> 🧠 Performance Mode</label><br>
-                <label>Font Size: <input type="text" id="re-fontSize" value="${settings.fontSize}"></label><br>
-                <label>Line Height: <input type="text" id="re-lineHeight" value="${settings.lineHeight}"></label><br>
-                <button id="re-save">💾 Save</button>
-                <button id="re-export">⬇️ Export</button>
-                <button id="re-import">⬆️ Import</button>
-                <button id="re-reset">🧼 Reset Settings</button>
-                <button id="re-reset-pos">📍 Reset Position</button>
-                <input type="file" id="re-import-file" style="display:none">
-            </div>
-        `;
+    // Build menu DOM safely without using innerHTML with untrusted data
+    const toggleButton = document.createElement("button");
+    toggleButton.id = "re-toggle";
+    toggleButton.title = "Reddit Enhancer Settings";
+    toggleButton.textContent = "⚙️";
+    menu.appendChild(toggleButton);
+
+    const panel = document.createElement("div");
+    panel.id = "re-panel";
+
+    function addCheckbox(id, labelText) {
+      const label = document.createElement("label");
+      const input = document.createElement("input");
+      input.type = "checkbox";
+      input.id = id;
+      label.appendChild(input);
+      label.appendChild(document.createTextNode(" " + labelText));
+      panel.appendChild(label);
+      panel.appendChild(document.createElement("br"));
+    }
+
+    addCheckbox("re-darkMode", "Dark Mode");
+    addCheckbox("re-hidePromoted", "Hide Promoted Posts");
+    addCheckbox("re-hideSuggested", "Hide Suggested Posts");
+    addCheckbox("re-wideMode", "Wide Layout");
+    addCheckbox("re-autoExpandComments", "Auto Expand Comments");
+    addCheckbox("re-autoRefresh", "Auto Refresh Feed");
+    addCheckbox("re-performanceMode", "🧠 Performance Mode");
+
+    function addTextInput(id, labelText) {
+      const label = document.createElement("label");
+      label.appendChild(document.createTextNode(labelText + ": "));
+      const input = document.createElement("input");
+      input.type = "text";
+      input.id = id;
+      label.appendChild(input);
+      panel.appendChild(label);
+      panel.appendChild(document.createElement("br"));
+    }
+
+    addTextInput("re-fontSize", "Font Size");
+    addTextInput("re-lineHeight", "Line Height");
+
+    function addButton(id, text) {
+      const btn = document.createElement("button");
+      btn.id = id;
+      btn.textContent = text;
+      panel.appendChild(btn);
+    }
+
+    addButton("re-save", "💾 Save");
+    addButton("re-export", "⬇️ Export");
+    addButton("re-import", "⬆️ Import");
+    addButton("re-reset", "🧼 Reset Settings");
+    addButton("re-reset-pos", "📍 Reset Position");
+
+    const importFileInput = document.createElement("input");
+    importFileInput.type = "file";
+    importFileInput.id = "re-import-file";
+    importFileInput.style.display = "none";
+    panel.appendChild(importFileInput);
+
+    menu.appendChild(panel);
+
     document.body.appendChild(menu);
 
     const ids = Object.keys(defaultSettings);


### PR DESCRIPTION
Potential fix for [https://github.com/Ven0m0/Ven0m0-Adblock/security/code-scanning/152](https://github.com/Ven0m0/Ven0m0-Adblock/security/code-scanning/152)

In general, to fix “DOM text reinterpreted as HTML” problems you need to avoid feeding untrusted strings into APIs that interpret them as HTML (`innerHTML`, jQuery `$()` with HTML-like strings, etc.). Instead, construct the DOM using element/attribute APIs (`createElement`, `textContent`, `setAttribute`) or ensure all untrusted data is contextually escaped before insertion.

Here, the best fix without changing functionality is:

- Stop using a big template literal with embedded `${settings.fontSize}` and `${settings.lineHeight}` in `menu.innerHTML`.
- Build the menu DOM structure with `document.createElement` / `appendChild` (or minimally, create the `input` elements separately), and set the font size and line height values via `input.value = settings.fontSize` and `input.value = settings.lineHeight`.
- This way, the untrusted values are assigned to the `value` property of `<input>` elements, which treats them as plain text and not as HTML, removing the tainted flow into `innerHTML`.

We only modify the shown snippet in `userscripts/todo/OTHER/Reddit_Enhancer_Performance_Mode_Tools_.user.js`, specifically the `menu.innerHTML = \`...\`` block and the immediate code that initializes the inputs, leaving logic and UI behavior intact.

Concretely:

- Replace lines 124–143 (the template literal assigned to `menu.innerHTML`) with code that:
  - Creates the toggle button (`re-toggle`) via `createElement("button")`.
  - Creates `re-panel` as a `<div>` with appropriate children:
    - `label` + `input` checkboxes for all toggles.
    - `label` + `input type="text"` for `re-fontSize` and `re-lineHeight` (without embedding any value in HTML).
    - Buttons and file input.
  - Appends these to `menu`.
- Keep the later lines that set:
  - `document.getElementById("re-fontSize").value = settings.fontSize;`
  - `document.getElementById("re-lineHeight").value = settings.lineHeight;`
  as they now safely populate those inputs without using `innerHTML`.

No new imports or libraries are required; only standard DOM APIs are used.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
