### PR TITLE
Potential fix for code scanning alert no. 149: DOM text reinterpreted as HTML

### DIFF
--- a/userscripts/todo/LLM/AI_Chat_Universal_Enhancer.user.js
+++ b/userscripts/todo/LLM/AI_Chat_Universal_Enhancer.user.js
@@ -364,9 +364,21 @@ CONSOLIDATED FEATURES:
             if (!link.href && link.innerText && link.innerText.trim()) {
               const linkText = link.innerText.trim();
               if (linkText.startsWith("http") || linkText.includes("www.")) {
-                link.href = linkText;
-                link.target = "_blank";
-                link.rel = "noopener noreferrer";
+                let candidateUrl = linkText;
+                // If the text looks like a bare domain (contains "www." but no scheme), prepend https://
+                if (!/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(candidateUrl) && candidateUrl.includes("www.")) {
+                  candidateUrl = "https://" + candidateUrl.replace(/^\/*/, "");
+                }
+                try {
+                  const url = new URL(candidateUrl, window.location.origin);
+                  if (url.protocol === "http:" || url.protocol === "https:") {
+                    link.href = url.toString();
+                    link.target = "_blank";
+                    link.rel = "noopener noreferrer";
+                  }
+                } catch (e) {
+                  // Ignore invalid URLs derived from innerText
+                }
               }
             }
           });


### PR DESCRIPTION
Potential fix for [https://github.com/Ven0m0/Ven0m0-Adblock/security/code-scanning/149](https://github.com/Ven0m0/Ven0m0-Adblock/security/code-scanning/149)

In general, to fix this type of issue you should never directly reuse DOM text as a URL or HTML without validating and constraining it. For URLs, parse the string, verify that it has a safe scheme (typically `http:` or `https:`), and then reconstruct a normalized URL. Reject or ignore values that do not parse correctly or that use any other scheme.

For this specific code, the minimal, behavior‑preserving fix is:

- Keep using the visible link text to construct the `href`, but:
  - Use the `URL` constructor to parse/normalize the candidate URL.
  - If it lacks a scheme but looks like a bare domain (`www.example.com`), prepend `https://` before parsing.
  - Only accept URLs whose `protocol` is `http:` or `https:`.
  - If parsing fails or the protocol is not allowed, skip setting `href` at all.

This keeps the existing functionality of turning “http://…“ and “www.…“ texts into clickable links, but avoids treating arbitrary text as a free‑form URL. All changes can be done in the shown `LinkEnhancer.enhance` method, inside the existing `if (linkText.startsWith("http") || linkText.includes("www.")) { ... }` block, without touching other parts of the script or adding external dependencies.

Concretely, inside `userscripts/todo/LLM/AI_Chat_Universal_Enhancer.user.js` around line 365–370, replace the current direct assignment of `link.href = linkText;` with logic that:

- Builds `candidateUrl` from `linkText` (prepending `https://` when needed),
- Tries `new URL(candidateUrl, window.location.origin)` inside a `try`/`catch`,
- Checks that `url.protocol === "http:" || url.protocol === "https:"`,
- Assigns `link.href = url.toString()` only if the check passes, and only then sets `target` and `rel`.

No new imports or helper functions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
