### PR TITLE
🧹 Remove redundant filename sanitization in update-lists.py

### DIFF
--- a/Scripts/update-lists.py
+++ b/Scripts/update-lists.py
@@ -159,8 +159,7 @@ async def fetch_list(
             await f.write(chunk)
 
         # Only call process once with the correct filename
-        safe_filename = sanitize_filename(url, filename)
-        result = await process_downloaded_file(tmp_path, url, safe_filename, output_dir, skip_checksum)
+        result = await process_downloaded_file(tmp_path, url, filename, output_dir, skip_checksum)
         return (url, result is not None)
       finally:
         # Ensure cleanup always


### PR DESCRIPTION
🎯 **What:** Removed redundant `sanitize_filename` call in `Scripts/update-lists.py` within `fetch_list` function.
💡 **Why:** To trust the canonical filename provided in the configuration and avoid double sanitization or accidental modification of filenames that are already safe/desired. This aligns with the codebase goal of using config-defined filenames as the source of truth.
✅ **Verification:** Added a new test case in `Scripts/test_update_lists.py` (`test_fetch_list_uses_raw_filename`) that verifies `fetch_list` passes the raw filename to `process_downloaded_file`. Ran existing tests to ensure no regressions.
✨ **Result:** The `fetch_list` function now correctly uses the provided filename directly.

---
*PR created automatically by Jules for task [7219788783643230525](https://jules.google.com/task/7219788783643230525) started by @Ven0m0*