### PR TITLE
🧹 fix: correct selector logic for Claude in LLM-pro user script

### DIFF
--- a/userscripts/src/LLM-pro.user.js
+++ b/userscripts/src/LLM-pro.user.js
@@ -155,7 +155,7 @@
             if (!el) return [];
             return [el.parentElement, el.parentElement?.parentElement].filter(Boolean);
           };
-    runReady((isCGPT ? SEL.CGPT.TEXT : SEL.GEMINI.BOX).split(",")[0], () => {
+    runReady((isCGPT ? SEL.CGPT.TEXT : isGem ? SEL.GEMINI.BOX : SEL.CLAUDE.RENDER).split(",")[0], () => {
       applyW(getEls);
       obsW(getEls);
     });


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
The `runReady` call in `userscripts/src/LLM-pro.user.js` had a faulty ternary operator that incorrectly mapped the Claude environment (`isCl`) to the Gemini selector (`SEL.GEMINI.BOX`). This was fixed to use the correct `SEL.CLAUDE.RENDER` selector for the Claude environment.

💡 **Why:** How this improves maintainability
This ensures the script reliably waits for the appropriate chat container to render across all three supported LLM platforms (ChatGPT, Gemini, and Claude) without relying on incorrect fallback assumptions.

✅ **Verification:** How you confirmed the change is safe
- Verified syntax correctness with `node --check`.
- Ran `bun run format` to ensure stylistic consistency.
- Confirmed the patch isolates the ternary conditional logic directly within `runReady` without side-effects.

✨ **Result:** The improvement achieved
The script now correctly monitors the Claude UI for its specific render element before applying layout optimizations, fully restoring intended functionality for Claude users while preserving stability for ChatGPT and Gemini.

---
*PR created automatically by Jules for task [12595655392913058480](https://jules.google.com/task/12595655392913058480) started by @Ven0m0*