### PR TITLE
fix: resolve layout issues in YouTube Music New Releases section

### DIFF
--- a/userscripts/todo/YT/YouTube_Music_Complete.user.js
+++ b/userscripts/todo/YT/YouTube_Music_Complete.user.js
@@ -107,7 +107,7 @@ CONSOLIDATED FEATURES:
           const button = document.querySelector(".song-button.style-scope.ytmusic-av-toggle");
           if (button) button.click();
         }
-      } catch (e) {
+      } catch {
         // Silently fail if elements not found
       }
     },
@@ -155,7 +155,6 @@ CONSOLIDATED FEATURES:
           const oldValue = hashMap.get(this);
           Promise.resolve([oldValue, newValue, new Date()]).then(fSet).catch(console.warn);
           hashMap.set(this, newValue);
-          return true;
         }
       });
     },
@@ -296,11 +295,14 @@ CONSOLIDATED FEATURES:
 
       ytmusic-carousel-shelf-renderer[system-id="new-releases"] .carousel {
         display: flex !important;
-        overflow-x: auto !important;
+        flex-wrap: wrap !important;
+        justify-content: flex-start !important;
       }
 
       ytmusic-carousel-shelf-renderer[system-id="new-releases"] .carousel-item {
         flex: 0 0 auto !important;
+        margin-right: 16px !important;
+        margin-bottom: 16px !important;
       }
     `);
   }


### PR DESCRIPTION
This pull request addresses the layout issue in the "New Releases" section of YouTube Music.

The previous layout attempted to enforce a single-line horizontal scroll (`overflow-x: auto`), which resulted in either squished items or an unusable carousel depending on viewport size. 

The fix modifies the CSS injected by the `ytmusic-carousel-shelf-renderer[system-id="new-releases"] .carousel` rule to be a wrapping flex container. This ensures that all releases are displayed uniformly in a grid layout across multiple rows.

**Changes included:**
- Switched `overflow-x: auto` to `flex-wrap: wrap` to enable a wrapping grid format.
- Added `justify-content: flex-start`.
- Maintained `.carousel-item` flex sizing (`flex: 0 0 auto`).
- Adjusted `.carousel-item` margins (`margin-right: 16px`, `margin-bottom: 16px`) to ensure proper spacing between the items in the grid.
- Cleaned up one unused variable and fixed a setter return type lint error.

Tested by verifying the mock rendered correctly. Lint errors were fixed and existing unit tests were green.

---
*PR created automatically by Jules for task [6434181785723539259](https://jules.google.com/task/6434181785723539259) started by @Ven0m0*