### PR TITLE
🧹 Remove unused import `ANY` in test_update_lists.py

### DIFF
--- a/Scripts/test_update_lists.py
+++ b/Scripts/test_update_lists.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock, patch, AsyncMock, ANY
+from unittest.mock import MagicMock, patch, AsyncMock
 import importlib.util
 import sys
 import json


### PR DESCRIPTION
🎯 **What:** Removed the unused `ANY` import from `unittest.mock` on line 2 in `Scripts/test_update_lists.py`.
💡 **Why:** Improves code maintainability and reduces namespace clutter.
✅ **Verification:** Ran the Python unit test suite `python3 -m unittest discover Scripts/ 'test_*.py'`, which verified that removing the import had no adverse effects on the tests.
✨ **Result:** Cleaner code health with no functional changes.

---
*PR created automatically by Jules for task [9731629773742737560](https://jules.google.com/task/9731629773742737560) started by @Ven0m0*