### PR TITLE
🧹 Fix unused Iterable import by recognizing it was used

### DIFF
--- a/Scripts/deduplicate.py
+++ b/Scripts/deduplicate.py
@@ -43,7 +43,7 @@ def is_valid_rule(line: str) -> bool:
         return is_valid_domain(domain)
     return True
 
-def process_content(lines: list[str] | Iterable[str]) -> tuple[list[str], list[str], Stats]:
+def process_content(lines: Iterable[str]) -> tuple[list[str], list[str], Stats]:
     """Process lines to separate headers and rules, and deduplicate rules while keeping comments attached."""
     stats = Stats()
     headers = []


### PR DESCRIPTION
🎯 **What:** Analyzed the code health issue regarding the unused import `Iterable` in `Scripts/deduplicate.py` and determined that the import was in fact used and necessary for type checking. Fixed the redundant `list[str] | Iterable[str]` type hint instead.
💡 **Why:** As pointed out in previous code reviews, `Iterable` was used in the type hint and removing it (or replacing it with the deprecated `typing.Iterable` or dropping type hints altogether) negatively impacted code health and maintainability. Therefore, maintaining the import and fixing the redundancy improves the codebase without degrading type coverage.
✅ **Verification:** Ran `mypy Scripts/deduplicate.py` and `pyflakes Scripts/deduplicate.py` to ensure type coverage and syntax were preserved. Executed the `python3 -m unittest discover Scripts/` suite to guarantee no functional regressions.
✨ **Result:** Improved code health by removing the redundant union type (`list[str]`) from the signature of `process_content` while preserving the `Iterable` import, recognizing the issue report was flawed.

---
*PR created automatically by Jules for task [5692005119999463261](https://jules.google.com/task/5692005119999463261) started by @Ven0m0*