### PR TITLE
🔒 Fix eval vulnerability in cleanup hooks

### DIFF
--- a/Scripts/hosts-creator.sh
+++ b/Scripts/hosts-creator.sh
@@ -52,7 +52,7 @@ process(){
   if [[ -n $awk_cmd ]]; then
     local tmp
     tmp=$(mktemp)
-    cleanup_add "rm -f $tmp"
+    cleanup_add rm -f "$tmp"
     awk "$awk_cmd" "$NEW_NAME" > "$tmp" && mv "$tmp" "$NEW_NAME"
     ok "Processed"
   fi

--- a/Scripts/lib-common.sh
+++ b/Scripts/lib-common.sh
@@ -42,6 +42,18 @@ ts_read() { TZ=UTC printf '%(%Y-%m-%d %H:%M:%S UTC)T\n' -1; }
 # CLEANUP HOOKS
 # ============================================================================
 _cleanup_hooks=()
-cleanup_add() { _cleanup_hooks+=("$1"); }
-cleanup_run() { local h; for h in "${_cleanup_hooks[@]}"; do eval "$h" || :; done; }
+cleanup_add() { _cleanup_hooks+=("$@" "__CLEANUP_DELIM__"); }
+cleanup_run() {
+  local cmd=() arg
+  for arg in "${_cleanup_hooks[@]}"; do
+    if [[ "$arg" == "__CLEANUP_DELIM__" ]]; then
+      if (( ${#cmd[@]} > 0 )); then
+        "${cmd[@]}" || :
+        cmd=()
+      fi
+    else
+      cmd+=("$arg")
+    fi
+  done
+}
 trap cleanup_run EXIT INT TERM


### PR DESCRIPTION
🎯 **What:** The `cleanup_run` function in `Scripts/lib-common.sh` utilized `eval` to execute cleanup commands. This patch replaces `eval` with a safer array-based implementation using array expansion to store arguments separated by a `__CLEANUP_DELIM__` delimiter. `Scripts/hosts-creator.sh` was appropriately refactored to pass command components independently to the hook function.

⚠️ **Risk:** While the cleanup hooks were mostly controlled locally, using `eval` to execute dynamic string commands poses significant security risks if shell metacharacters or unsanitized strings are ever injected, which could lead to arbitrary command execution. Additionally, it causes complications when dealing with strings that contain spaces.

🛡️ **Solution:** `cleanup_add` has been modified to accept arrays of arguments (e.g. `cleanup_add rm -f "$tmp"`) appending a delimiter at the end to separate the instructions. The `cleanup_run` function iterates over the hook list array, executing the commands with standard `"${cmd[@]}"` array expansion rather than a string evaluation, removing any risk of eval-based code execution or string manipulation problems.

---
*PR created automatically by Jules for task [1163696222110505462](https://jules.google.com/task/1163696222110505462) started by @Ven0m0*