### PR TITLE
🔒 fix: scope down GITHUB_TOKEN permissions in userscripts workflow

### DIFF
--- a/.github/workflows/userscripts.yml
+++ b/.github/workflows/userscripts.yml
@@ -28,7 +28,7 @@ on:
         type: boolean
         default: false
 permissions:
-  contents: write
+  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -36,6 +36,8 @@ concurrency:
 jobs:
   build:
     name: Build & Optimize
+    outputs:
+      has_changes: ${{ steps.detect.outputs.has_changes }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -149,18 +151,6 @@ jobs:
           done
           printf '\n---\n*Built on %s*\n' "$(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> dist/README.md
 
-      - name: Commit and push changes
-        if: |
-          steps.detect.outputs.has_changes == 'true' &&
-          github.event_name != 'pull_request'
-        uses: stefanzweifel/git-auto-commit-action@v7
-        with:
-          commit_message: "ci: build and optimize userscripts [skip ci]"
-          file_pattern: "dist/*.js dist/README.md userscripts/dist/*.js"
-          commit_user_name: "github-actions[bot]"
-          commit_user_email: "41898282+github-actions[bot]@users.noreply.github.com"
-          skip_dirty_check: false
-
       - name: Upload artifacts
         if: steps.detect.outputs.has_changes == 'true'
         uses: actions/upload-artifact@v7
@@ -169,4 +159,28 @@ jobs:
           path: |
             dist/*.js
             dist/README.md
+            userscripts/dist/*.js
           retention-days: 30
+
+  deploy:
+    name: Commit and Push
+    needs: build
+    if: github.event_name != 'pull_request' && needs.build.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Download artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: userscripts-${{ github.sha }}
+      - name: Commit and push changes
+        uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          commit_message: "ci: build and optimize userscripts [skip ci]"
+          file_pattern: "dist/*.js dist/README.md userscripts/dist/*.js"
+          commit_user_name: "github-actions[bot]"
+          commit_user_email: "41898282+github-actions[bot]@users.noreply.github.com"
+          skip_dirty_check: false


### PR DESCRIPTION
🎯 **What:** This PR fixes an overly permissive `GITHUB_TOKEN` in the `.github/workflows/userscripts.yml` workflow.

⚠️ **Risk:** The previous configuration granted `contents: write` permissions globally to all jobs and steps. This meant that any code executed during a `pull_request` event—including untrusted code from external contributors—could potentially modify the repository's contents.

🛡️ **Solution:** The fix implements the principle of least privilege by:
1. Setting the global default permission to `contents: read`.
2. Splitting the workflow into two separate jobs: `build` and `deploy`.
3. Isolating the `contents: write` permission to the `deploy` job only.
4. Adding an explicit condition (`if: github.event_name != 'pull_request'`) to the `deploy` job to ensure write access is never granted during pull request builds.
5. Using GitHub Actions artifacts to securely transfer built files from the restricted `build` job to the `deploy` job.

---
*PR created automatically by Jules for task [3265514078663909303](https://jules.google.com/task/3265514078663909303) started by @Ven0m0*