### PR TITLE
🧪 Add tests for write_lines append mode exceptions

### DIFF
--- a/Scripts/test_common.py
+++ b/Scripts/test_common.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 if str(Path(__file__).parent) not in sys.path:
     sys.path.append(str(Path(__file__).parent))
 
-from common import sanitize_filename, is_valid_domain, read_lines
+from common import sanitize_filename, is_valid_domain, read_lines, write_lines
 
 
 class TestCommon(unittest.TestCase):
@@ -104,8 +104,6 @@ class TestCommon(unittest.TestCase):
                 self.assertIn(f"Error reading {non_existent}", mock_stderr.getvalue())
 
     def test_write_lines_atomic(self):
-        from common import write_lines
-
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_dir_path = Path(temp_dir)
             target_file = temp_dir_path / "target.txt"
@@ -127,6 +125,35 @@ class TestCommon(unittest.TestCase):
             self.assertEqual(
                 target_file.read_text(encoding="utf-8"), "line3\nline4\nline5\n"
             )
+
+    def test_write_lines_append_exception(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_dir_path = Path(temp_dir)
+            target_file = temp_dir_path / "target.txt"
+
+            with patch("pathlib.Path.open") as mock_open:
+                mock_open.side_effect = OSError("Access denied")
+                with patch("sys.stderr", new_callable=io.StringIO) as mock_stderr:
+                    result = write_lines(target_file, ["line1"], mode="a")
+                    self.assertFalse(result)
+                    self.assertIn(
+                        f"Error writing {target_file}", mock_stderr.getvalue()
+                    )
+
+    def test_write_lines_append_write_exception(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_dir_path = Path(temp_dir)
+            target_file = temp_dir_path / "target.txt"
+
+            with patch("pathlib.Path.open") as mock_open:
+                mock_file = mock_open.return_value.__enter__.return_value
+                mock_file.write.side_effect = OSError("Disk full")
+                with patch("sys.stderr", new_callable=io.StringIO) as mock_stderr:
+                    result = write_lines(target_file, ["line1"], mode="a")
+                    self.assertFalse(result)
+                    self.assertIn(
+                        f"Error writing {target_file}", mock_stderr.getvalue()
+                    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the lack of exception handling tests for the `write_lines` function in `Scripts/common.py` when operating in append mode (`mode="a"`).

📊 **Coverage:** 
- Added `test_write_lines_append_exception`: Verifies that an `OSError` during the `open()` call is caught, returns `False`, and logs to `stderr`.
- Added `test_write_lines_append_write_exception`: Verifies that an `OSError` during the `write()` call is caught, returns `False`, and logs to `stderr`.
- Refactored `Scripts/test_common.py` to use a module-level import for `write_lines`.

✨ **Result:** Improved the robustness of the test suite by ensuring that error handling logic in the core `write_lines` utility is verified.

---
*PR created automatically by Jules for task [7772658306139050421](https://jules.google.com/task/7772658306139050421) started by @Ven0m0*