### PR TITLE
🔒 Fix path traversal vulnerability in update_lists.py

### DIFF
--- a/Scripts/update_lists.py
+++ b/Scripts/update_lists.py
@@ -100,7 +100,7 @@ async def process_downloaded_file(
     skip_checksum: bool = False,
 ) -> Path | None:
     """Process and move temp file to final destination."""
-    dest_path = output_dir / filename
+    dest_path = output_dir / Path(filename).name
 
     try:
         async with aiofiles.open(temp_path, mode="r", encoding="utf-8") as f:


### PR DESCRIPTION
🎯 **What:** Fixed a path traversal vulnerability in `Scripts/update_lists.py` where the `filename` extracted from the configuration was directly joined with `output_dir` using `pathlib.Path`.
⚠️ **Risk:** An attacker or malicious configuration could provide a filename containing directory traversal characters (e.g., `../malicious.txt` or absolute paths). This would allow an arbitrary file write outside of the intended `output_dir`, potentially compromising the system.
🛡️ **Solution:** Used `Path(filename).name` to extract only the base name of the file before joining it with the `output_dir`, mitigating the path traversal by disregarding any directory path components provided in the untrusted `filename`.

---
*PR created automatically by Jules for task [16757411069770788981](https://jules.google.com/task/16757411069770788981) started by @Ven0m0*