### PR TITLE
🔒 Reduce PR permissions to read-only in pull_request workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
🎯 **What:** The `pull_request.yml` GitHub action was using the overly permissive `pull-requests: write` permission.
⚠️ **Risk:** A compromised dependency, a malicious script, or even a hijacked action could potentially modify pull requests (e.g., approving them, modifying them, etc.) when only read access is needed for running the `biome ci .` and formatting tasks. This violates the principle of least privilege.
🛡️ **Solution:** Reduced the permission to `pull-requests: read` for the `quality` job in `.github/workflows/pull_request.yml`. This restricts access strictly to reading pull request properties, which is all that is necessary for formatting and linting tasks, fixing the potential vulnerability.

---
*PR created automatically by Jules for task [5945403264177683505](https://jules.google.com/task/5945403264177683505) started by @Ven0m0*