### PR TITLE
🧹 Refactor `apply_updates` in `move_pure_domains.py` to reduce cyclomatic complexity

### DIFF
--- a/Scripts/move_pure_domains.py
+++ b/Scripts/move_pure_domains.py
@@ -95,8 +95,8 @@ def scan_adblock_files(adblock_dir: Path) -> tuple[dict, dict]:
     return domain_moves, file_updates
 
 
-def apply_updates(hostlist_dir: Path, domain_moves: dict, file_updates: dict) -> int:
-    """Append domains to hostlists and update source files."""
+def _update_hostlists(hostlist_dir: Path, domain_moves: dict) -> int:
+    """Append domains to hostlists."""
     total_moved = 0
 
     print("\n" + "=" * 60)
@@ -135,6 +135,11 @@ def apply_updates(hostlist_dir: Path, domain_moves: dict, file_updates: dict) ->
                 total_moved += len(new_domains)
                 print(f"Appended {len(new_domains)} domains to {target_file}")
 
+    return total_moved
+
+
+def _update_source_files(file_updates: dict) -> None:
+    """Update source adblock files."""
     print("\n" + "=" * 60)
     print("Updating source adblock files")
     print("=" * 60 + "\n")
@@ -148,6 +153,11 @@ def apply_updates(hostlist_dir: Path, domain_moves: dict, file_updates: dict) ->
             if tmp_path.exists():
                 tmp_path.unlink()
 
+
+def apply_updates(hostlist_dir: Path, domain_moves: dict, file_updates: dict) -> int:
+    """Append domains to hostlists and update source files."""
+    total_moved = _update_hostlists(hostlist_dir, domain_moves)
+    _update_source_files(file_updates)
     return total_moved
 
 


### PR DESCRIPTION
🎯 **What:** Extracted inner logic of `apply_updates` in `Scripts/move_pure_domains.py` into two separate helper functions: `_update_hostlists` and `_update_source_files`.
💡 **Why:** The original `apply_updates` function had high cyclomatic complexity by handling both the hostlist domain appending and the source adblock file updates in a single, large control block. Separating these concerns makes the code much easier to read, test, and maintain.
✅ **Verification:** Verified by checking formatting with `ruff` and running the full Python unit test suite `unittest discover`. All tests pass, ensuring no existing functionality is broken.
✨ **Result:** Improved modularity and readability in `Scripts/move_pure_domains.py` without modifying behavior.

---
*PR created automatically by Jules for task [652345217091328388](https://jules.google.com/task/652345217091328388) started by @Ven0m0*