### PR TITLE
🔒 fix: prevent command injection in dead domains check workflow

### DIFF
--- a/.github/workflows/dead-domains-check.yml
+++ b/.github/workflows/dead-domains-check.yml
@@ -52,9 +52,12 @@ jobs:
           echo "hostlist_files=$hostlist_files" >> $GITHUB_OUTPUT
 
       - name: Export Dead Domains
+        env:
+          ADBLOCK_FILES: ${{ steps.filter-files.outputs.adblock_files }}
+          HOSTLIST_FILES: ${{ steps.filter-files.outputs.hostlist_files }}
         run: |
           mkdir -p dead-domains
-          for file in ${{ steps.filter-files.outputs.adblock_files }} ${{ steps.filter-files.outputs.hostlist_files }}; do
+          for file in $ADBLOCK_FILES $HOSTLIST_FILES; do
             if [[ -f "$file" ]]; then
               mise exec -- bunx dead-domains-linter --export "dead-domains/$(basename "$file").txt" --input "$file" 2>/dev/null || true
             fi
@@ -133,8 +136,11 @@ jobs:
 
       - name: Remove Dead Domains
         if: steps.read-dead-domains.outputs.has_dead_domains == 'true'
+        env:
+          ADBLOCK_FILES: ${{ steps.filter-files.outputs.adblock_files }}
+          HOSTLIST_FILES: ${{ steps.filter-files.outputs.hostlist_files }}
         run: |
-          for file in ${{ steps.filter-files.outputs.adblock_files }} ${{ steps.filter-files.outputs.hostlist_files }}; do
+          for file in $ADBLOCK_FILES $HOSTLIST_FILES; do
             if [[ -f "$file" ]]; then
               mise exec -- bunx dead-domains-linter --auto --import "dead-domains/$(basename "$file").txt" --input "$file" --output "$file" 2>/dev/null || true
             fi


### PR DESCRIPTION
🎯 **What:** Replaced GitHub Actions string interpolation (`${{ }}`) inside the bash scripts with environment variables in the `.github/workflows/dead-domains-check.yml` workflow.

⚠️ **Risk:** Unquoted template expressions inside bash scripts can lead to arbitrary command execution if an attacker manages to inject malicious data into the interpolated variables (e.g. if the filenames or paths could somehow be modified to contain command characters).

🛡️ **Solution:** Migrated the list of file paths to the `env` context of the relevant steps and accessed them as bash variables (`$ADBLOCK_FILES`, `$HOSTLIST_FILES`). This safely passes the data as environment variables, preventing interpolation vulnerabilities while still correctly handling the expected word-splitting behavior in the `for` loops.

---
*PR created automatically by Jules for task [4485077558042399857](https://jules.google.com/task/4485077558042399857) started by @Ven0m0*