### PR TITLE
🧪 Add unit tests for deduplicate main method

### DIFF
--- a/Scripts/test_deduplicate.py
+++ b/Scripts/test_deduplicate.py
@@ -1,7 +1,13 @@
+import sys
+import tempfile
+from pathlib import Path
+from io import StringIO
+from unittest.mock import patch
 import unittest
 
 # Add current directory to path to allow importing deduplicate
 from Scripts.deduplicate import (
+    main,
     process_content,
     is_header,
     is_valid_rule,
@@ -106,6 +112,65 @@ class TestDeduplicate(unittest.TestCase):
 
         # Test empty input
         self.assertEqual(find_cross_file_duplicates({}), {})
+
+
+class TestMain(unittest.TestCase):
+    def test_main_with_valid_directory(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            tmpdir = Path(tmpdirname)
+
+            # Create a test file
+            file1 = tmpdir / "file1.txt"
+            file1.write_text("rule1.com\nrule1.com\nrule2.com\n")
+
+            # Create another test file
+            file2 = tmpdir / "file2.txt"
+            file2.write_text("rule2.com\nrule3.com\n")
+
+            with (
+                patch.object(sys, "argv", ["deduplicate.py", str(tmpdir)]),
+                patch("sys.stdout", new=StringIO()),
+                patch("sys.stderr", new=StringIO()),
+            ):
+                result = main()
+
+            self.assertEqual(result, 0)
+
+            # Check files were deduplicated
+            self.assertEqual(file1.read_text(), "rule1.com\nrule2.com\n")
+            self.assertEqual(file2.read_text(), "rule2.com\nrule3.com\n")
+
+    def test_main_directory_not_found(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            tmpdir = Path(tmpdirname) / "nonexistent"
+
+            with (
+                patch.object(sys, "argv", ["deduplicate.py", str(tmpdir)]),
+                patch("sys.stderr", new_callable=StringIO) as mock_stderr,
+                patch("sys.stdout", new_callable=StringIO),
+            ):
+                result = main()
+
+            self.assertEqual(result, 1)
+            self.assertIn("Error: Lists directory not found", mock_stderr.getvalue())
+
+    def test_main_no_txt_files(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            tmpdir = Path(tmpdirname)
+
+            # Create a non-txt file
+            file1 = tmpdir / "file1.log"
+            file1.write_text("rule1.com\n")
+
+            with (
+                patch.object(sys, "argv", ["deduplicate.py", str(tmpdir)]),
+                patch("sys.stderr", new_callable=StringIO) as mock_stderr,
+                patch("sys.stdout", new_callable=StringIO),
+            ):
+                result = main()
+
+            self.assertEqual(result, 1)
+            self.assertIn("No .txt files found", mock_stderr.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
🎯 **What:** The `main` method in `Scripts/deduplicate.py` lacked unit tests, creating a testing gap.
📊 **Coverage:** The new tests now explicitly cover executing `main` using a valid directory with files to be deduplicated, handling of non-existent directories, and directories with no `.txt` files.
✨ **Result:** Test coverage for `deduplicate.py` has been significantly increased and potential regressions with its main execution flow will now be caught by the test suite.

---
*PR created automatically by Jules for task [13402012100767396292](https://jules.google.com/task/13402012100767396292) started by @Ven0m0*