### PR TITLE
🧪 Add tests for common.py exception paths

### DIFF
--- a/Scripts/test_common.py
+++ b/Scripts/test_common.py
@@ -93,6 +93,15 @@ class TestCommon(unittest.TestCase):
             lines = read_lines(target_file)
             self.assertEqual(lines, ["line1", "line2", "line3"])
 
+    @patch("pathlib.Path.open")
+    def test_read_lines_unicode_error(self, mock_open):
+        mock_open.side_effect = UnicodeError("mock unicode error")
+        with patch("sys.stderr", new_callable=io.StringIO) as mock_stderr:
+            lines = read_lines(Path("dummy.txt"))
+            self.assertIsNone(lines)
+            self.assertIn("Error reading dummy.txt", mock_stderr.getvalue())
+            self.assertIn("mock unicode error", mock_stderr.getvalue())
+
     def test_read_lines_file_not_found(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_dir_path = Path(temp_dir)
@@ -127,6 +136,28 @@ class TestCommon(unittest.TestCase):
             self.assertEqual(
                 target_file.read_text(encoding="utf-8"), "line3\nline4\nline5\n"
             )
+
+    @patch("pathlib.Path.open")
+    def test_write_lines_os_error_append(self, mock_open):
+        from common import write_lines
+
+        mock_open.side_effect = OSError("mock os error append")
+        with patch("sys.stderr", new_callable=io.StringIO) as mock_stderr:
+            result = write_lines(Path("dummy.txt"), ["line1"], mode="a")
+            self.assertFalse(result)
+            self.assertIn("Error writing dummy.txt", mock_stderr.getvalue())
+            self.assertIn("mock os error append", mock_stderr.getvalue())
+
+    @patch("tempfile.mkstemp")
+    def test_write_lines_os_error_atomic(self, mock_mkstemp):
+        from common import write_lines
+
+        mock_mkstemp.side_effect = OSError("mock os error atomic")
+        with patch("sys.stderr", new_callable=io.StringIO) as mock_stderr:
+            result = write_lines(Path("dummy.txt"), ["line1"], mode="w")
+            self.assertFalse(result)
+            self.assertIn("Error writing dummy.txt", mock_stderr.getvalue())
+            self.assertIn("mock os error atomic", mock_stderr.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
🎯 **What:** The testing gap in `Scripts/common.py` addressed by adding missing test coverage for exception paths in `read_lines` and `write_lines`.
📊 **Coverage:** Scenarios involving `UnicodeError` during `read_lines`, and `OSError` during `write_lines` (both append mode via `Path.open` and atomic mode via `tempfile.mkstemp`) are now fully covered and verified to correctly return expected fallbacks while logging to `stderr`.
✨ **Result:** Enhanced test coverage provides greater confidence in standard file I/O operations and exception catching paths, contributing to a more robust codebase.

---
*PR created automatically by Jules for task [2159744246152701660](https://jules.google.com/task/2159744246152701660) started by @Ven0m0*