### PR TITLE
fix: update hostlist-compiler configs to fix compilation

### DIFF
--- a/.kilo/kilo.json
+++ b/.kilo/kilo.json
@@ -1,121 +1,125 @@
 {
-	"$schema": "https://app.kilo.ai/config.json",
-	"instructions": [".kilo/rules/*.md", "AGENTS.md"],
-	"skills": { "paths": [".kilo/skills", ".claude/skills"] },
-	"permission": {
-		"*": "allow",
-		"read": { "*.env": "deny", "*.lock": "deny", "*": "allow" },
-		"edit": { "*.lock": "deny", "*": "allow" },
-		"sudo *": "deny",
-		"rm -rf /": "deny",
-		"rm -rf /*": "deny",
-		"rm -rf ~": "deny",
-		"rm -rf ~/*": "deny",
-		":(){:|:&};:": "deny",
-		"doom_loop": "deny"
-	},
-	"provider": {
-		"openai": {
-			"options": { "apiKey": "{env:OPENAI_API_KEY}" }
-		},
-		"anthropic": {
+  "$schema": "https://app.kilo.ai/config.json",
+  "instructions": [".kilo/rules/*.md", "AGENTS.md"],
+  "skills": { "paths": [".kilo/skills", ".claude/skills"] },
+  "permission": {
+    "*": "allow",
+    "read": { "*.env": "deny", "*.lock": "deny", "*": "allow" },
+    "edit": { "*.lock": "deny", "*": "allow" },
+    "sudo *": "deny",
+    "rm -rf /": "deny",
+    "rm -rf /*": "deny",
+    "rm -rf ~": "deny",
+    "rm -rf ~/*": "deny",
+    ":(){:|:&};:": "deny",
+    "doom_loop": "deny"
+  },
+  "provider": {
+    "openai": {
+      "options": { "apiKey": "{env:OPENAI_API_KEY}" }
+    },
+    "anthropic": {
       "options": { "apiKey": "{env:ANTHROPIC_API_KEY}" }
-		}
-	},
-	"disabled_providers": ["openai", "google", "anthropic"],
-	"plugin": [
-		"opencode-ignore@1.1.0",
+    }
+  },
+  "disabled_providers": ["openai", "google", "anthropic"],
+  "plugin": [
+    "opencode-ignore@1.1.0",
     "@bastiangx/opencode-unmoji",
-		"@gotgenes/opencode-agent-identity@3.0.1",
-		"@nick-vi/opencode-type-inject@1.1.2",
+    "@gotgenes/opencode-agent-identity@3.0.1",
+    "@nick-vi/opencode-type-inject@1.1.2",
     "@openspoon/subtask2@0.3.9",
-		"@tarquinen/opencode-dcp@3.1.9",
-		"openslimedit@1.0.4",
+    "@tarquinen/opencode-dcp@3.1.9",
+    "openslimedit@1.0.4",
     "opencode-agent-memory@0.2.0",
     "superpowers@git+https://github.com/obra/superpowers.git"
-	],
-	"formatter": {
-		"biome": {
-			"command": ["npx", "-y", "@biomejs/biome", "check", "--write", "--format-with-errors=true", "$FILE"],
-			"extensions": [".json", ".jsonc", ".js", ".ts"]
-		},
-		"ruff": {
-			"command": ["ruff", "format", "$FILE"],
-			"extensions": [".py", ".pyi",".pyc"]
-		}
-	},
-	"watcher": {
-		"ignore": ["node_modules/**", "dist/**", ".git/**", ".venv/**", "__pycache__/**", ".ruff_cache/**"]
-	},
-	"mcp": {
-		"ref-tools": {
-			"type": "remote",
-			"url": "https://api.ref.tools/mcp",
-			"enabled": true
-		},
-		"github": {
-			"type": "remote",
-			"url": "https://api.githubcopilot.com/mcp/",
-			"enabled": true
-		},
-		"exa": {
-			"type": "remote",
-			"url": "https://mcp.exa.ai/mcp?tools=web_search_exa,web_search_advanced_exa,get_code_context_exa,crawling_exa",
-			"enabled": true,
-			"headers": { "x-api-key": "{env:EXA_API_KEY}" }
-		},
-		"serena": {
-			"type": "local",
-			"command": [
-				"uvx", "--from",
-				"git+https://github.com/oraios/serena",
-				"serena", "start-mcp-server",
-				"--context", "ide", "--project-from-cwd"
-			],
-			"enabled": true
-		},
-		"octocode": {
-			"type": "local",
-			"command": ["npx", "-y", "octocode-mcp@latest"],
-			"enabled": true
-		},
+  ],
+  "formatter": {
+    "biome": {
+      "command": ["npx", "-y", "@biomejs/biome", "check", "--write", "--format-with-errors=true", "$FILE"],
+      "extensions": [".json", ".jsonc", ".js", ".ts"]
+    },
+    "ruff": {
+      "command": ["ruff", "format", "$FILE"],
+      "extensions": [".py", ".pyi", ".pyc"]
+    }
+  },
+  "watcher": {
+    "ignore": ["node_modules/**", "dist/**", ".git/**", ".venv/**", "__pycache__/**", ".ruff_cache/**"]
+  },
+  "mcp": {
+    "ref-tools": {
+      "type": "remote",
+      "url": "https://api.ref.tools/mcp",
+      "enabled": true
+    },
+    "github": {
+      "type": "remote",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "enabled": true
+    },
+    "exa": {
+      "type": "remote",
+      "url": "https://mcp.exa.ai/mcp?tools=web_search_exa,web_search_advanced_exa,get_code_context_exa,crawling_exa",
+      "enabled": true,
+      "headers": { "x-api-key": "{env:EXA_API_KEY}" }
+    },
+    "serena": {
+      "type": "local",
+      "command": [
+        "uvx",
+        "--from",
+        "git+https://github.com/oraios/serena",
+        "serena",
+        "start-mcp-server",
+        "--context",
+        "ide",
+        "--project-from-cwd"
+      ],
+      "enabled": true
+    },
+    "octocode": {
+      "type": "local",
+      "command": ["npx", "-y", "octocode-mcp@latest"],
+      "enabled": true
+    },
     "morph-mcp": {
       "type": "local",
       "command": ["npx", "-y", "@morphllm/morphmcp"],
       "environment": { "MORPH_API_KEY": "{env:MORPH_API_KEY}" },
       "enabled": true
     }
-	},
-	"lsp": {
-		"basedpyright": {
-			"command": ["basedpyright-langserver", "--stdio"],
-			"extensions": [".py", ".pyw", ".pyi"]
-		},
-		"bash": {
-			"command": ["bash-language-server", "start"],
-			"extensions": [".sh", ".bash", ".zsh"]
-		},
-		"vtsls": {
+  },
+  "lsp": {
+    "basedpyright": {
+      "command": ["basedpyright-langserver", "--stdio"],
+      "extensions": [".py", ".pyw", ".pyi"]
+    },
+    "bash": {
+      "command": ["bash-language-server", "start"],
+      "extensions": [".sh", ".bash", ".zsh"]
+    },
+    "vtsls": {
       "command": ["vtsls", "--stdio"],
       "extensions": [".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".mts", ".cts"],
       "initialization": { "preferences": { "importModuleSpecifierPreference": "relative" } }
-		},
+    },
     "rust": {
       "command": ["rust-analyzer"],
       "extensions": [".rs"]
     },
-		"yaml-ls": {
-			"command": ["yaml-language-server", "--stdio"],
-			"extensions": [".yaml", ".yml"]
-		},
-		"json-ls": {
-			"command": ["vscode-json-language-server", "--stdio"],
-			"extensions": [".json", ".jsonc"]
-		},
-		"tombi": {
-			"command": ["tombi", "lsp"],
-			"extensions": [".toml"]
-		},
+    "yaml-ls": {
+      "command": ["yaml-language-server", "--stdio"],
+      "extensions": [".yaml", ".yml"]
+    },
+    "json-ls": {
+      "command": ["vscode-json-language-server", "--stdio"],
+      "extensions": [".json", ".jsonc"]
+    },
+    "tombi": {
+      "command": ["tombi", "lsp"],
+      "extensions": [".toml"]
+    },
     "dockerfile-ls": {
       "command": ["docker-langserver", "--stdio"],
       "extensions": [".dockerfile"]
@@ -128,20 +132,23 @@
       "command": ["vscode-css-language-server", "--stdio"],
       "extensions": [".css", ".scss", ".less"]
     },
-		"powershell": {
-			"command": [
-				"pwsh", "-NoLogo", "-NoProfile", "-Command",
-				"$module = Get-Module -ListAvailable PowerShellEditorServices | Sort-Object Version -Descending | Select-Object -First 1; if (-not $module) { throw 'PowerShellEditorServices is not installed. Run: Install-Module -Name PowerShellEditorServices -Scope CurrentUser' }; Import-Module $module.Path; Start-EditorServices -HostName 'Claude Code' -HostProfileId 'ClaudeCode' -HostVersion '1.0.0' -Stdio -BundledModulesPath (Split-Path $module.Path) -LogPath '/dev/null' -LogLevel 'None' -EnableConsoleRepl"
-			],
-			"extensions": [".ps1", ".psm1", ".psd1"]
-		}
-	},
-	"compaction": { "auto": true, "prune": true },
-	"experimental": {
-		"continue_loop_on_deny": false,
-		"codebase_search": true,
-		"mcp_timeout": 30000,
-		"openTelemetry": false,
-		"batch_tool": true
-	}
+    "powershell": {
+      "command": [
+        "pwsh",
+        "-NoLogo",
+        "-NoProfile",
+        "-Command",
+        "$module = Get-Module -ListAvailable PowerShellEditorServices | Sort-Object Version -Descending | Select-Object -First 1; if (-not $module) { throw 'PowerShellEditorServices is not installed. Run: Install-Module -Name PowerShellEditorServices -Scope CurrentUser' }; Import-Module $module.Path; Start-EditorServices -HostName 'Claude Code' -HostProfileId 'ClaudeCode' -HostVersion '1.0.0' -Stdio -BundledModulesPath (Split-Path $module.Path) -LogPath '/dev/null' -LogLevel 'None' -EnableConsoleRepl"
+      ],
+      "extensions": [".ps1", ".psm1", ".psd1"]
+    }
+  },
+  "compaction": { "auto": true, "prune": true },
+  "experimental": {
+    "continue_loop_on_deny": false,
+    "codebase_search": true,
+    "mcp_timeout": 30000,
+    "openTelemetry": false,
+    "batch_tool": true
+  }
 }

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2,7 +2,7 @@
 
 ## Pending
 
-- [ ] Finish hostlist-compiler configs (`hostlist-config.json`, `lists/conf.json`) — see [HostlistCompiler](https://github.com/AdguardTeam/HostlistCompiler) and [example config](https://github.com/AdguardTeam/AdGuardSDNSFilter/blob/master/configuration.json)
+- [x] Finish hostlist-compiler configs (`hostlist-config.json`, `lists/conf.json`) — see [HostlistCompiler](https://github.com/AdguardTeam/HostlistCompiler) and [example config](https://github.com/AdguardTeam/AdGuardSDNSFilter/blob/master/configuration.json)
 - [ ] Review and consolidate cross-file duplicates in filter lists
 - [ ] Migrate remaining Python scripts to Bun/JS for CI portability
 

--- a/hostlist-config.json
+++ b/hostlist-config.json
@@ -16,7 +16,7 @@
       "name": "Search engine tracking and ads"
     },
     {
-      "source": "lists/sources/TwitterAnnoyances.txt",
+      "source": "lists/sources/Twitter.txt",
       "type": "adblock",
       "name": "Twitter/X annoyances and tracking"
     }

--- a/lists/conf.json
+++ b/lists/conf.json
@@ -9,28 +9,28 @@
       "source": "https://adguardteam.github.io/AdguardFilters/BaseFilter/sections/adservers.txt",
       "type": "adblock",
       "exclusions_sources": ["Filters/exclusions.txt"],
-      "transformations": ["RemoveModifiers", "ValidateAllowIp", "Validate", "RemoveComments", "Deduplicate", "Compress"]
+      "transformations": ["RemoveModifiers", "Validate", "RemoveComments", "Deduplicate", "Compress"]
     },
     {
       "name": "AdGuard Base filter ad servers first-party",
       "source": "https://adguardteam.github.io/AdguardFilters/BaseFilter/sections/adservers_firstparty.txt",
       "type": "adblock",
       "exclusions_sources": ["Filters/exclusions.txt"],
-      "transformations": ["RemoveModifiers", "ValidateAllowIp"]
+      "transformations": ["RemoveModifiers"]
     },
     {
       "name": "AdGuard Base filter ad servers foreign",
       "source": "https://adguardteam.github.io/AdguardFilters/BaseFilter/sections/foreign.txt",
       "type": "adblock",
       "exclusions_sources": ["Filters/exclusions.txt"],
-      "transformations": ["RemoveModifiers", "ValidateAllowIp"]
+      "transformations": ["RemoveModifiers"]
     },
     {
       "name": "AdGuard Base filter cryptominers",
       "source": "https://adguardteam.github.io/AdguardFilters/BaseFilter/sections/cryptominers.txt",
       "type": "adblock",
       "exclusions_sources": ["Filters/exclusions.txt"],
-      "transformations": ["RemoveModifiers", "ValidateAllowIp"]
+      "transformations": ["RemoveModifiers"]
     },
     {
       "name": "EasyList ad servers",
@@ -87,28 +87,28 @@
       "source": "https://adguardteam.github.io/AdguardFilters/MobileFilter/sections/adservers.txt",
       "type": "adblock",
       "exclusions_sources": ["Filters/exclusions.txt"],
-      "transformations": ["RemoveModifiers", "ValidateAllowIp"]
+      "transformations": ["RemoveModifiers"]
     },
     {
       "name": "AdGuard Tracking Protection filter third-party trackers",
       "source": "https://adguardteam.github.io/AdguardFilters/SpywareFilter/sections/tracking_servers.txt",
       "type": "adblock",
       "exclusions_sources": ["Filters/exclusions.txt"],
-      "transformations": ["RemoveModifiers", "ValidateAllowIp"]
+      "transformations": ["RemoveModifiers"]
     },
     {
       "name": "AdGuard Tracking Protection filter first-party trackers",
       "source": "https://adguardteam.github.io/AdguardFilters/SpywareFilter/sections/tracking_servers_firstparty.txt",
       "type": "adblock",
       "exclusions_sources": ["Filters/exclusions.txt"],
-      "transformations": ["RemoveModifiers", "ValidateAllowIp"]
+      "transformations": ["RemoveModifiers"]
     },
     {
       "name": "AdGuard Tracking Protection filter mobile trackers",
       "source": "https://adguardteam.github.io/AdguardFilters/SpywareFilter/sections/mobile.txt",
       "type": "adblock",
       "exclusions_sources": ["Filters/exclusions.txt"],
-      "transformations": ["RemoveModifiers", "ValidateAllowIp"]
+      "transformations": ["RemoveModifiers"]
     },
     {
       "name": "EasyPrivacy tracking servers",


### PR DESCRIPTION
Fixed the hostlist-compiler configurations as requested in the TODO item.
- `hostlist-config.json`: Updated `TwitterAnnoyances.txt` to `Twitter.txt` since the former was renamed and didn't exist anymore, which caused compilation failures.
- `lists/conf.json`: Removed the unsupported `ValidateAllowIp` transformation from all items with `"type": "adblock"`. Using `ValidateAllowIp` on adblock lists causes validation errors in `hostlist-compiler` because it expects this transformation only for specific formats like hosts.
- `docs/TODO.md`: Marked the `Finish hostlist-compiler configs` task as complete.

---
*PR created automatically by Jules for task [8302661724912871862](https://jules.google.com/task/8302661724912871862) started by @Ven0m0*