### PR TITLE
⚡ Fix paste handler newlines fallback in Claude Enhancement userscript

### DIFF
--- a/userscripts/todo/LLM/Claude_Complete_Enhancement.user.js
+++ b/userscripts/todo/LLM/Claude_Complete_Enhancement.user.js
@@ -180,7 +180,11 @@ IMPROVEMENTS OVER ORIGINALS:
           // Preserve multiple newlines better than default behavior
           if (text.includes('\n')) {
             text = text.replace(/\r\n/g, '\n');
-            document.execCommand("insertText", false, text);
+            const success = document.execCommand("insertText", false, text);
+            if (!success && typeof active.setRangeText === "function") {
+              active.setRangeText(text, active.selectionStart, active.selectionEnd, "end");
+              active.dispatchEvent(new Event("input", { bubbles: true, cancelable: true }));
+            }
             e.preventDefault();
           }
         }


### PR DESCRIPTION
**💡 What**
Added a fallback mechanism to the custom `paste` event handler in `Claude_Complete_Enhancement.user.js` for when `document.execCommand("insertText")` fails to insert text with newlines.

**🎯 Why**
The userscript overrides paste behavior to preserve multiple newlines. However, in certain environments (like Firefox or specific Chrome setups), `document.execCommand("insertText")` fails inside `<textarea>` or `<input>` elements, returning `false` and resulting in nothing being pasted. The fallback uses `HTMLInputElement.setRangeText` or `HTMLTextAreaElement.setRangeText` combined with manually dispatching an `input` event to ensure the text is properly inserted and registered by the underlying React framework.

**📊 Measured Improvement**
Pasting multi-line strings into input fields and textareas now successfully inserts the formatted text even if the primary `execCommand` API fails.

---
*PR created automatically by Jules for task [12245236676955697124](https://jules.google.com/task/12245236676955697124) started by @Ven0m0*