### PR TITLE
fix: adjust New Releases section layout CSS

### DIFF
--- a/userscripts/todo/YT/YouTube_Music_Complete.user.js
+++ b/userscripts/todo/YT/YouTube_Music_Complete.user.js
@@ -346,6 +346,7 @@ CONSOLIDATED FEATURES:
       /* Fix New Releases section layout */
       ytmusic-carousel-shelf-renderer[system-id="new-releases"] {
         display: block !important;
+        width: 100% !important;
       }
 
       ytmusic-carousel-shelf-renderer[system-id="new-releases"] .carousel {
@@ -353,12 +354,17 @@ CONSOLIDATED FEATURES:
         flex-wrap: nowrap !important;
         overflow-x: auto !important;
         justify-content: flex-start !important;
+        gap: 16px !important;
+        scrollbar-width: none !important; /* Firefox */
+      }
+
+      ytmusic-carousel-shelf-renderer[system-id="new-releases"] .carousel::-webkit-scrollbar {
+        display: none !important; /* Safari and Chrome */
       }
 
       ytmusic-carousel-shelf-renderer[system-id="new-releases"] .carousel-item {
         flex: 0 0 auto !important;
-        margin-right: 16px !important;
-        margin-bottom: 16px !important;
+        margin: 0 !important;
       }
     `);
   }


### PR DESCRIPTION
Replaced margin-based spacing on individual carousel items with flex `gap` on the parent container. Corrected the scrollable layout by applying `width: 100%` and added CSS rules to explicitly hide native scrollbars in Firefox (`scrollbar-width: none`) and WebKit (`::-webkit-scrollbar { display: none; }`) browsers to present a clean horizontal scrolling experience.

---
*PR created automatically by Jules for task [8746513639511453103](https://jules.google.com/task/8746513639511453103) started by @Ven0m0*