### PR TITLE
fix: correctly handle newlines in contentEditable paste handler

### DIFF
--- a/userscripts/todo/LLM/Claude_Complete_Enhancement.user.js
+++ b/userscripts/todo/LLM/Claude_Complete_Enhancement.user.js
@@ -183,6 +183,26 @@ IMPROVEMENTS OVER ORIGINALS:
             if (!success && typeof active.setRangeText === "function") {
               active.setRangeText(text, active.selectionStart, active.selectionEnd, "end");
               active.dispatchEvent(new Event("input", { bubbles: true, cancelable: true }));
+            } else if (!success && active.isContentEditable) {
+              const selection = window.getSelection();
+              if (selection && selection.rangeCount) {
+                const range = selection.getRangeAt(0);
+                range.deleteContents();
+
+                const fragment = document.createDocumentFragment();
+                const lines = text.split('\n');
+                lines.forEach((line, i) => {
+                  if (line) {
+                    fragment.appendChild(document.createTextNode(line));
+                  }
+                  if (i < lines.length - 1) {
+                    fragment.appendChild(document.createElement("br"));
+                  }
+                });
+                range.insertNode(fragment);
+                range.collapse(false);
+                active.dispatchEvent(new Event("input", { bubbles: true, cancelable: true }));
+              }
             }
             e.preventDefault();
           }


### PR DESCRIPTION
Fixes a bug where pasting text with multiple newlines into a `contentEditable` element within the Claude enhancement userscript failed to properly preserve paragraph breaks, because `document.execCommand('insertText')` sometimes fails in those scenarios, and `setRangeText` only works for text inputs.

Instead of only falling back to `setRangeText`, we now construct a `DocumentFragment` split by `\n` mapped to `<br>` elements and `Range.insertNode()` to accurately construct multi-line inputs in `contentEditable` targets safely.

---
*PR created automatically by Jules for task [1172147727416933816](https://jules.google.com/task/1172147727416933816) started by @Ven0m0*